### PR TITLE
Init/first implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
 # messages-queue
+
+A simple Java-based message queue implementation with file storage.
+
+## Features
+
+- **Thread-safe message queue** using `BlockingQueue`
+- **Unique message IDs** - automatically generated UUIDs for each message
+- **File-based storage** - messages survive application restarts
+
+## Classes
+
+### [`Message`](src/main/java/com/ofek/queue/Message.java)
+
+Represents a message with:
+
+- Unique ID (UUID)
+- String payload
+- Two constructors:
+  - `Message(String payload)` - creates new message with generated ID
+  - `Message(String id, String payload)` - loads existing message with preserved ID
+
+### [`MessageQueue`](src/main/java/com/ofek/queue/MessageQueue.java)
+
+The main messages queue implementation with:
+
+- `enqueue(Message message)` - adds message to queue and saves to file
+- `dequeue()` - removes and returns message from queue
+- `size()` - returns current queue size
+- Automatic file loading on startup
+- Saves messages to a specified file
+
+### [`App`](src/main/java/com/ofek/queue/App.java)
+
+Demo application showing basic usage
+
+## Usage
+
+```java
+// Create a message queue with file storage
+MessageQueue queue = new MessageQueue("messages.log");
+
+// Add messages
+queue.enqueue(new Message("Hello, World!"));
+
+// Retrieve messages
+Message delivered = queue.dequeue();
+
+// Check queue size
+int size = queue.size();
+```
+
+## Building and Running
+
+This is a Maven project. To build and run:
+
+```bash
+# Compile
+mvn compile
+
+# Run the demo
+mvn exec:java -Dexec.mainClass="com.ofek.queue.App"
+
+# Run tests
+mvn test
+```
+
+## File Format
+
+Messages are stored in pipe-delimited format:
+
+```
+UUID|payload
+another-uuid|another message
+```
+
+## Requirements
+
+- Java 21
+- Maven 3.x

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,13 @@
   <version>1.0-SNAPSHOT</version>
   <name>messages-queue</name>
   <url>http://maven.apache.org</url>
+
+    <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/ofek/queue/App.java
+++ b/src/main/java/com/ofek/queue/App.java
@@ -1,13 +1,15 @@
 package com.ofek.queue;
 
-/**
- * Hello world!
- *
- */
-public class App 
-{
-    public static void main( String[] args )
-    {
-        System.out.println( "Hello World!" );
+public class App {
+    public static void main(String[] args) {
+        MessageQueue queue = new MessageQueue("messages.log");
+
+        queue.enqueue(new Message("Hello, World!"));
+
+        Message delivered = queue.dequeue();
+        System.out.println("Delivered: " + delivered);
+
+        System.out.println("Queue size: " + queue.size());
+
     }
 }

--- a/src/main/java/com/ofek/queue/Message.java
+++ b/src/main/java/com/ofek/queue/Message.java
@@ -1,0 +1,37 @@
+package com.ofek.queue;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public class Message implements Serializable {
+    private final String id;
+    private final String payload;
+
+    // Constructor for new messages (generates new ID)
+    public Message(String payload) {
+        this.id = UUID.randomUUID().toString();
+        this.payload = payload;
+    }
+
+    // Constructor for loading existing messages (preserves original ID)
+    public Message(String id, String payload) {
+        this.id = id;
+        this.payload = payload;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    @Override
+    public String toString() {
+        return "Message{" +
+                "id='" + id + '\'' +
+                ", payload='" + payload + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/ofek/queue/MessageQueue.java
+++ b/src/main/java/com/ofek/queue/MessageQueue.java
@@ -1,0 +1,68 @@
+package com.ofek.queue;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class MessageQueue {
+    private final BlockingQueue<Message> queue = new LinkedBlockingQueue<>();
+    private final Path messagesFilePath;
+
+    public MessageQueue(String filename) {
+        this.messagesFilePath = Path.of(filename);
+        loadMessagesFromFile();
+    }
+
+    public void enqueue(Message message) {
+        queue.offer(message);
+        saveMessageToFile(message);
+        System.out.println("Enqueued: " + message);
+    }
+
+    public Message dequeue() {
+        return queue.poll();
+    }
+
+    public int size() {
+        return queue.size();
+    }
+
+    private void saveMessageToFile(Message message) {
+        try (BufferedWriter writer = Files.newBufferedWriter(
+                messagesFilePath, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+            writer.write(message.getId() + "|" + message.getPayload());
+            writer.newLine();
+        } catch (IOException e) {
+            System.out.println("Error saving message to file: " + e.getMessage());
+        }
+    }
+
+    private void loadMessagesFromFile() {
+        if (!Files.exists(messagesFilePath)) {
+            System.out.println("File " + messagesFilePath + " doesn't exist. Starting with empty queue.");
+            return;
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(messagesFilePath)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String[] parts = line.split("\\|", 2);
+                if (parts.length == 2) {
+                    String id = parts[0];
+                    String payload = parts[1];
+                    Message message = new Message(id, payload);
+                    queue.offer(message);
+                }
+            }
+        } catch (IOException e) {
+            System.out.println("Error loading messages from file: " + e.getMessage());
+        }
+
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a Java-based message queue implementation with file-based storage.
This includes creating core classes for the message and queue functionality, running demo application, and enhancing documentation and build configuration.

### Core functionality:

* **`Message` class**: Implements a serializable message object with unique IDs and string payloads. It provides constructors for creating new messages or loading existing ones. (`src/main/java/com/ofek/queue/Message.java`)
* **`MessageQueue` class**: Implements a thread-safe message queue using `BlockingQueue`. It supports file-based persistence, ensuring messages survive application restarts. (`src/main/java/com/ofek/queue/MessageQueue.java`)

### Documentation and build configuration:

* **`README.md`**: Adds detailed documentation about the project, including features, class descriptions, usage examples, and build instructions. (`README.md`)
* **`pom.xml`**: Configures Maven to use Java 21 and sets UTF-8 as the source encoding. (`pom.xml`)