### PR TITLE
chore: add test CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        java-version: [21]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK ${{ matrix.java-version }}
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java-version }}
+          java-version: "21"
           distribution: "temurin"
           cache: maven
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the continuous integration (CI) process for the repository. The workflow is designed to run tests on code changes pushed to the `main` branch or submitted via pull requests, excluding markdown file updates.

### CI Workflow Implementation:

* `.github/workflows/ci.yml`: Added a new CI workflow that:
  - Runs on `push` and `pull_request` events targeting the `main` branch, ignoring changes to markdown files (`*.md`). 
  - Sets up permissions to read repository contents.
  - Defines a job to test the code using JDK 21 and Maven, with caching for Maven dependencies to optimize build times.