### PR TITLE
Feature/byte based messages

### DIFF
--- a/src/main/java/com/ofek/queue/Message.java
+++ b/src/main/java/com/ofek/queue/Message.java
@@ -1,37 +1,34 @@
 package com.ofek.queue;
 
 import java.io.Serializable;
-import java.util.UUID;
+import java.nio.charset.StandardCharsets;
 
 public class Message implements Serializable {
-    private final String id;
-    private final String payload;
+    private final byte[] payload;
 
-    // Constructor for new messages (generates new ID)
+    // Constructor for new messages
+    public Message(byte[] payload) {
+        this.payload = payload.clone();
+    }
+
+    // Constructor for String payload
     public Message(String payload) {
-        this.id = UUID.randomUUID().toString();
-        this.payload = payload;
+        this.payload = payload.getBytes(StandardCharsets.UTF_8);
     }
 
-    // Constructor for loading existing messages (preserves original ID)
-    public Message(String id, String payload) {
-        this.id = id;
-        this.payload = payload;
+    public byte[] getPayload() {
+        return payload.clone();
     }
 
-    public String getId() {
-        return id;
-    }
-
-    public String getPayload() {
-        return payload;
+    // Get payload as String
+    public String getPayloadAsString() {
+        return new String(payload, StandardCharsets.UTF_8);
     }
 
     @Override
     public String toString() {
         return "Message{" +
-                "id='" + id + '\'' +
-                ", payload='" + payload + '\'' +
+                ", payload='" + getPayloadAsString() + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/ofek/queue/Producer.java
+++ b/src/main/java/com/ofek/queue/Producer.java
@@ -12,4 +12,9 @@ public class Producer {
         messageQueue.enqueue(message);
     }
 
+    public void produce(byte[] payload) {
+        Message message = new Message(payload);
+        messageQueue.enqueue(message);
+    }
+
 }

--- a/src/test/java/com/ofek/queue/ConsumerTest.java
+++ b/src/test/java/com/ofek/queue/ConsumerTest.java
@@ -41,7 +41,7 @@ public class ConsumerTest {
 
         Message message = consumer.poll();
         assertNotNull(message);
-        assertEquals("Test message", message.getPayload());
+        assertEquals("Test message", message.getPayloadAsString());
         assertEquals(0, messageQueue.size());
     }
 
@@ -59,7 +59,7 @@ public class ConsumerTest {
         for (int i = 0; i < messageCount; i++) {
             Message message = consumer.poll();
             assertNotNull(message);
-            assertEquals("Message " + i, message.getPayload());
+            assertEquals("Message " + i, message.getPayloadAsString());
         }
 
         assertEquals(0, messageQueue.size());
@@ -102,7 +102,7 @@ public class ConsumerTest {
 
         Message msg1 = consumer.poll();
         assertNotNull(msg1);
-        assertEquals("Message 1", msg1.getPayload());
+        assertEquals("Message 1", msg1.getPayloadAsString());
         assertEquals(0, messageQueue.size());
 
         producer.produce("Message 2");
@@ -110,7 +110,7 @@ public class ConsumerTest {
 
         Message msg2 = consumer.poll();
         assertNotNull(msg2);
-        assertEquals("Message 2", msg2.getPayload());
+        assertEquals("Message 2", msg2.getPayloadAsString());
         assertEquals(0, messageQueue.size());
     }
 
@@ -126,7 +126,7 @@ public class ConsumerTest {
 
         Message message = consumer.poll();
         assertNotNull(message);
-        assertEquals(largePayload.toString(), message.getPayload());
+        assertEquals(largePayload.toString(), message.getPayloadAsString());
         assertEquals(0, messageQueue.size());
     }
 
@@ -137,7 +137,7 @@ public class ConsumerTest {
 
         Message message = consumer.poll();
         assertNotNull(message);
-        assertEquals("", message.getPayload());
+        assertEquals("", message.getPayloadAsString());
         assertEquals(0, messageQueue.size());
     }
 
@@ -158,7 +158,7 @@ public class ConsumerTest {
         for (int i = 0; i < consumeCount; i++) {
             Message message = consumer.poll();
             assertNotNull(message);
-            assertEquals("Message " + i, message.getPayload());
+            assertEquals("Message " + i, message.getPayloadAsString());
         }
 
         assertEquals(totalMessages - consumeCount, messageQueue.size());
@@ -167,7 +167,7 @@ public class ConsumerTest {
         for (int i = consumeCount; i < totalMessages; i++) {
             Message message = consumer.poll();
             assertNotNull(message);
-            assertEquals("Message " + i, message.getPayload());
+            assertEquals("Message " + i, message.getPayloadAsString());
         }
 
         assertEquals(0, messageQueue.size());
@@ -181,6 +181,6 @@ public class ConsumerTest {
 
         Message message = consumer.poll();
         assertNotNull(message);
-        assertEquals(specialPayload, message.getPayload());
+        assertEquals(specialPayload, message.getPayloadAsString());
     }
 }

--- a/src/test/java/com/ofek/queue/IntegrationTest.java
+++ b/src/test/java/com/ofek/queue/IntegrationTest.java
@@ -52,7 +52,7 @@ public class IntegrationTest {
         for (int i = 0; i < consumeCount; i++) {
             Message message = batchConsumer.poll();
             assertNotNull(message);
-            assertEquals("Workflow message " + i, message.getPayload());
+            assertEquals("Workflow message " + i, message.getPayloadAsString());
         }
 
         assertEquals(messageCount - consumeCount, batchQueue.size());
@@ -78,7 +78,7 @@ public class IntegrationTest {
         for (int i = 0; i < messageCount; i++) {
             Message message = recoveredConsumer.poll();
             assertNotNull(message);
-            assertEquals("Workflow message " + i, message.getPayload());
+            assertEquals("Workflow message " + i, message.getPayloadAsString());
         }
 
         recoveredQueue.shutdown();
@@ -176,7 +176,7 @@ public class IntegrationTest {
         for (int i = 0; i < consumedInPhase1; i++) {
             Message message = initialConsumer.poll();
             assertNotNull(message);
-            assertEquals("Restart test message " + i, message.getPayload());
+            assertEquals("Restart test message " + i, message.getPayloadAsString());
         }
 
         // Simulate system shutdown
@@ -195,7 +195,7 @@ public class IntegrationTest {
         for (int i = 0; i < messageCount; i++) {
             Message message = restartedConsumer.poll();
             assertNotNull(message);
-            assertEquals("Restart test message " + i, message.getPayload());
+            assertEquals("Restart test message " + i, message.getPayloadAsString());
         }
 
         assertEquals(0, restartedQueue.size());
@@ -261,19 +261,19 @@ public class IntegrationTest {
 
         // Consume and verify
         Message msg1 = mixedConsumer.poll();
-        assertEquals("Short", msg1.getPayload());
+        assertEquals("Short", msg1.getPayloadAsString());
 
         Message msg2 = mixedConsumer.poll();
-        assertEquals("Medium length message with some content", msg2.getPayload());
+        assertEquals("Medium length message with some content", msg2.getPayloadAsString());
 
         Message msg3 = mixedConsumer.poll();
-        assertEquals(longMessage.toString(), msg3.getPayload());
+        assertEquals(longMessage.toString(), msg3.getPayloadAsString());
 
         Message msg4 = mixedConsumer.poll();
-        assertEquals("", msg4.getPayload());
+        assertEquals("", msg4.getPayloadAsString());
 
         Message msg5 = mixedConsumer.poll();
-        assertEquals("Final message", msg5.getPayload());
+        assertEquals("Final message", msg5.getPayloadAsString());
 
         assertEquals(0, mixedQueue.size());
 

--- a/src/test/java/com/ofek/queue/ProducerTest.java
+++ b/src/test/java/com/ofek/queue/ProducerTest.java
@@ -41,7 +41,7 @@ public class ProducerTest {
 
         Message message = messageQueue.dequeue();
         assertNotNull(message);
-        assertEquals("Test message", message.getPayload());
+        assertEquals("Test message", message.getPayloadAsString());
     }
 
     @Test
@@ -58,7 +58,7 @@ public class ProducerTest {
         for (int i = 0; i < messageCount; i++) {
             Message message = messageQueue.dequeue();
             assertNotNull(message);
-            assertEquals("Message " + i, message.getPayload());
+            assertEquals("Message " + i, message.getPayloadAsString());
         }
     }
 
@@ -71,7 +71,7 @@ public class ProducerTest {
 
         Message message = messageQueue.dequeue();
         assertNotNull(message);
-        assertEquals("", message.getPayload());
+        assertEquals("", message.getPayloadAsString());
     }
 
     @Test
@@ -88,27 +88,7 @@ public class ProducerTest {
 
         Message message = messageQueue.dequeue();
         assertNotNull(message);
-        assertEquals(largePayload.toString(), message.getPayload());
-    }
-
-    @Test
-    @DisplayName("Should generate unique message IDs")
-    void testUniqueMessageIds() {
-        producer.produce("Same payload");
-        producer.produce("Same payload");
-        producer.produce("Same payload");
-
-        Message msg1 = messageQueue.dequeue();
-        Message msg2 = messageQueue.dequeue();
-        Message msg3 = messageQueue.dequeue();
-
-        assertNotNull(msg1);
-        assertNotNull(msg2);
-        assertNotNull(msg3);
-
-        assertNotEquals(msg1.getId(), msg2.getId());
-        assertNotEquals(msg2.getId(), msg3.getId());
-        assertNotEquals(msg1.getId(), msg3.getId());
+        assertEquals(largePayload.toString(), message.getPayloadAsString());
     }
 
     @Test
@@ -121,6 +101,6 @@ public class ProducerTest {
 
         Message message = messageQueue.dequeue();
         assertNotNull(message);
-        assertEquals(specialPayload, message.getPayload());
+        assertEquals(specialPayload, message.getPayloadAsString());
     }
 }


### PR DESCRIPTION
This pull request refactors the `Message` and `MessageQueue` classes to improve payload handling by switching from `String` to `byte[]` for payload storage. It also updates serialization to use Base64 encoding for safer storage and modifies tests to reflect these changes.

### Core Refactoring and Enhancements:
* **Payload storage refactor**: Changed `Message` class to store payloads as `byte[]` instead of `String`, added helper methods for encoding/decoding payloads as strings, and removed the `id` field for simplicity. (`src/main/java/com/ofek/queue/Message.java`)
* **Base64 encoding for persistence**: Updated `MessageQueue` to encode message payloads as Base64 when saving to files and decode them when loading. (`src/main/java/com/ofek/queue/MessageQueue.java`) [[1]](diffhunk://#diff-6e047db08d42a45758d1da3f361ef1681d6e5abc5b4354b3d0b2738a3d359a7aL162-R165) [[2]](diffhunk://#diff-6e047db08d42a45758d1da3f361ef1681d6e5abc5b4354b3d0b2738a3d359a7aL185-L193)

### API Changes:
* **New overload for `produce`**: Added a method in `Producer` to accept `byte[]` payloads directly. (`src/main/java/com/ofek/queue/Producer.java`)

### Test Updates:
* **Test compatibility**: Updated all test cases to use `getPayloadAsString()` for assertions instead of directly accessing `getPayload()`. (`src/test/java/com/ofek/queue/ConsumerTest.java`, `src/test/java/com/ofek/queue/IntegrationTest.java`, `src/test/java/com/ofek/queue/MessageQueueTest.java`) [[1]](diffhunk://#diff-ac8ec33ff03110765868f5c42f186b5d71ee9a49a33342e770c54f3729f8fa2eL44-R44) [[2]](diffhunk://#diff-962396c2e7f9b3290a1ad01528793768651355e352ea270719fda60cdd40d9e4L55-R55) [[3]](diffhunk://#diff-7e77ff70d69aaa1c8404f2548998f5a7947aa46a2df8000956734bdb3badffc9L66-R69)
* **File format validation**: Modified tests to decode Base64-encoded payloads when verifying file persistence. (`src/test/java/com/ofek/queue/MessageQueueTest.java`) [[1]](diffhunk://#diff-7e77ff70d69aaa1c8404f2548998f5a7947aa46a2df8000956734bdb3badffc9L134-R136) [[2]](diffhunk://#diff-7e77ff70d69aaa1c8404f2548998f5a7947aa46a2df8000956734bdb3badffc9L169-R170) [[3]](diffhunk://#diff-7e77ff70d69aaa1c8404f2548998f5a7947aa46a2df8000956734bdb3badffc9L198-R200)

### Cleanup:
* **Removed message ID**: Dropped the `id` field and related logic from `Message` and associated tests, simplifying the class. (`src/main/java/com/ofek/queue/Message.java`, `src/test/java/com/ofek/queue/MessageQueueTest.java`) [[1]](diffhunk://#diff-ac47c43e5c09c8a80084c41563144c9d5d5f762d6521d46aa10d43112f0b63f7L4-R31) [[2]](diffhunk://#diff-7e77ff70d69aaa1c8404f2548998f5a7947aa46a2df8000956734bdb3badffc9L330-L358)

These changes improve the flexibility of payload handling, ensure safe storage of binary data, and streamline the codebase.